### PR TITLE
Update GitHub workflow to set script permissions

### DIFF
--- a/.github/workflows/run-uat.yml
+++ b/.github/workflows/run-uat.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Install cypress dependencies
         run: npm ci
 
+      - name: Set script permissions
+        run: chmod +x ./deploy-script.sh
+
       - name: Start Application
         run: ./deploy-script.sh &
 


### PR DESCRIPTION
This commit updates the 'run-uat.yml' GitHub workflow file. It includes a new step within the job that assigns executable permissions to the 'deploy-script.sh' file. This ensures that the script can be executed within the GitHub Actions environment.