### PR TITLE
Add workflow_dispatch trigger to run-uat GitHub Action

### DIFF
--- a/.github/workflows/run-uat.yml
+++ b/.github/workflows/run-uat.yml
@@ -4,6 +4,8 @@ on:
   repository_dispatch:
     types: [trigger-uat-event]
 
+  workflow_dispatch:
+
 jobs:
   triggered-job:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This commit adds a new workflow_dispatch trigger to the run-uat.yml GitHub Action workflow. This allows users to manually trigger the GitHub Actions workflow for user acceptance testing through the GitHub interface.