### PR TITLE
Update Cypress selectors in E2E test

### DIFF
--- a/cypress/e2e/message.spec.cy.js
+++ b/cypress/e2e/message.spec.cy.js
@@ -4,7 +4,7 @@ describe('Message form UAT', () => {
     // When I type new message ID
     cy.get('.message-id-input').type('cypress');
     // And I type message value
-    cy.get('.message-value-input').type('hello from cypress');
+    cy.get('.message-value').type('hello from cypress');
     // And I press create message button
     cy.get('.create-message-button').click();
     //Then I expect to see message value
@@ -19,7 +19,7 @@ describe('Message form UAT', () => {
     //Then I expect to see message value
     cy.get('.message-value').should('have.value', 'hello from cypress');
     // When I alter message value
-    cy.get('.message-value-input').clear().type('updated message');
+    cy.get('.message-value').clear().type('updated message');
     // And I press update message button
     cy.get('.update-message-button').click();
     // I expect to see message value


### PR DESCRIPTION
This commit updates the Cypress selectors used in the message.spec.cy.js file. Previously, the selectors targeted elements with the class '.message-value-input', but they have now been updated to target '.message-value' to accurately reflect changes in the markup.